### PR TITLE
fix: workspace manifest does not parse — dep:symthaea references a stripped dependency

### DIFF
--- a/crates/domains/symthaea-psych-bench/Cargo.toml
+++ b/crates/domains/symthaea-psych-bench/Cargo.toml
@@ -13,7 +13,12 @@ categories = ["science", "algorithms"]
 
 [features]
 default = []
-symthaea-backend = ["symthaea-core/ctc_wiring", "dep:symthaea"]
+# [standalone-stripped] `dep:symthaea` removed. The `symthaea` path dependency is stripped
+# from the standalone export (see the commented line in [dependencies] below), and Cargo
+# rejects outright a feature that references a dependency which does not exist — failing
+# `cargo metadata` for the WHOLE workspace before anything compiles. The feature stays
+# declared so downstream references still resolve; it simply cannot enable the backend here.
+symthaea-backend = ["symthaea-core/ctc_wiring"]
 neuroevolution = ["dep:symthaea-neuroevolution"]
 neural_validation = ["symthaea-core/neural_validation"]  # TRIBE v2 fMRI comparison benchmark
 nuclear-benchmarks = ["dep:symthaea-nuclear"]            # Nuclear physics science benchmarks


### PR DESCRIPTION

`cargo metadata --no-deps` exits 101 on `main`, before anything compiles, so the
ENTIRE public workspace is unbuildable via a plain cargo build/test/check.

symthaea-psych-bench's `symthaea-backend` feature references `dep:symthaea`, but
the `symthaea` path dependency is commented out by the standalone export's
path-stripping (`# [standalone-stripped] symthaea = { path = "../../.." ... }`).
Cargo rejects a feature referencing a nonexistent dependency outright, and one
bad member manifest fails metadata resolution for the whole workspace.

Fix keeps the feature declared, so anything referencing `symthaea-backend` still
resolves, and drops only the stripped-dependency reference. The feature simply
cannot enable that backend in the standalone, which is already true — the
dependency it needed is not exported.

Verified: `cargo metadata --no-deps` goes 101 -> 0, resolving 201 members, in a
clean shallow clone of `main` (6710a3f) with no other local changes.

Context: this was diagnosed while investigating why a full-matrix CI dispatch on
`main` (run 30641796129) reported 46 of 62 jobs failing with 0 cancelled — the
first uncancelled full run this repo has had, after the workflow concurrency fix.
Format Check, Clippy, Documentation Tests and Test (default features) all fail
here, which is the signature of a workspace that cannot resolve rather than of
many independent defects. This is expected to clear a substantial fraction of
them; it is not expected to clear all of them.

Known and NOT addressed here: the standalone's sync provenance is under
investigation (Luminous-Dynamics/luminous-dynamics#25 — `sync-to-standalone.sh`
is disabled because it copied a live working tree and labeled the result with a
commit that did not contain it). This PR is a targeted manifest repair against
current `main`, not a re-sync, and deliberately does not touch that.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)